### PR TITLE
fix improper change detection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,8 +26,9 @@ resource "aws_ce_anomaly_monitor" "account" {
     Or             = null
 
     Tags = {
-      Key    = "LINKED_ACCOUNT"
-      Values = var.account_list
+      Key          = "user:LINKED_ACCOUNT"
+      MatchOptions = null
+      Values       = var.account_list
     }
   })
 }


### PR DESCRIPTION
closes https://github.com/synapsestudios/terraform-aws-cost-anomaly-monitor/issues/16

- fix: prepend `user:` to `LINKED_ACCOUNT` key, and set `MatchOptions` to `null` to prevent improper change detection